### PR TITLE
BugFix: garantir a persistência do atributo cargo_id ao modelo Funcionário

### DIFF
--- a/backend/app/Models/Funcionario.php
+++ b/backend/app/Models/Funcionario.php
@@ -27,13 +27,13 @@ class Funcionario extends Model
         'endereco',
         'data_admissao',
         'salario',
+        'cargo_id',
         'status',
 
         // TODO: campos que podem ser adicionados futuramente
         // 'cep',
         // 'cidade',
         // 'estado',
-        // 'cargo_id',
         // 'departamento',
         // 'tipo_contrato',
         // 'carga_horaria_semanal',


### PR DESCRIPTION
Ajustar o erro ao gravar o registro do Funcionário: 
O campo cargo_id não estava sendo salvo (persistido).